### PR TITLE
Enable wct testing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,10 @@
   "devDependencies": {
     "web-component-tester": "*",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "paper-button": "PolymerElements/paper-button#^1.0.0",
+    "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",
+    "paper-input": "PolymerElements/paper-input#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,17 +1,101 @@
 <!doctype html>
 <html>
-  <head>
-    <title>linkedin-signin</title>
+	<head>
+        <title>linkedin-signin</title>
 
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../linkedin-signin.html">
-  </head>
-  <body>
-	<linkedin-signin client-id="YOUR_KEY_HERE"></linkedin-signin>
-	<linkedin-signin client-id="YOUR_KEY_HERE"
-					 fields="id,num-connections,picture-url"></linkedin-signin>
-  </body>
+        <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+        <link rel="import" href="../../paper-styles/demo-pages.html">
+        <link rel="import" href="../../paper-input/paper-input.html">
+        <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
+        <link rel="import" href="../../paper-button/paper-button.html">
+        <link rel="import" href="../linkedin-signin.html">
+
+        <style>
+            .input {
+                margin-bottom: 20px;
+            }
+
+            .init-hint {
+                color: red;
+                margin-top: 20px;
+            }
+        </style>
+	</head>
+
+	<body>
+		<template is="dom-bind">
+            <h2>Step 1: Configure element</h2>
+            <div class="vertical-section">
+                <div class="input">
+                    <paper-input value="{{key}}" label="Your LinkedIn key" disabled="[[initialized]]"></paper-input>
+                    <paper-input value="{{fields}}" label="Fields to request" disabled="[[initialized]]"></paper-input>
+                    <paper-input value="{{lang}}" label="Preferred language" disabled="[[initialized]]"></paper-input>
+                    <paper-checkbox checked="{{authorize}}" disabled="[[initialized]]">Auto login</paper-checkbox>
+                </div>
+                <paper-button on-tap="init" raised disabled="[[initialized]]">Start</paper-button>
+
+                <div class="init-hint" hidden=[[!initialized]]>The key can't be changed once the LinkedIn element was initialized. Reload this page to use another key.</div>
+            </div>
+
+            <h2>Step 2: Try element</h2>
+            <div class="vertical-section">
+                <div hidden=[[initialized]]>Enter your LinkedIn key and click the [Start] button</div>
+
+                <template is="dom-if" if="[[initialized]]">
+                    <linkedin-signin
+                        client-id="[[key]]"
+                        fields="[[fields]]"
+                        authorize="[[authorize]]"
+                        lang="[[lang]]"
+                        signed-in="{{signedIn}}"
+                        button-ready="{{buttonReady}}"
+                        person="{{person}}"
+                        error="{{error}}"
+                        o-auth-data="{{oAuthData}}">
+                    </linkedin-signin>
+                </template>
+            </div>
+
+            <div class="vertical-section-container" hidden="[[!initialized]]">
+                <h2>Exposed properties</h2>
+                <h4>buttonReady</h4>
+                <div class="vertical-section">
+                    [[buttonReady]]
+                </div>
+                <h4>signedIn</h4>
+                <div class="vertical-section">
+                    [[signedIn]]
+                </div>
+                <h4>person</h4>
+                <div class="vertical-section">
+                    [[stringify(person)]]
+                </div>
+                <h4>error</h4>
+                <div class="vertical-section">
+                    [[error]]
+                </div>
+                <h4>oAuthData</h4>
+                <div class="vertical-section">
+                    [[stringify(oAuthData)]]
+                </div>
+            </div>
+		</template>
+
+        <script>
+            var scope = document.querySelector('template[is=dom-bind]');
+            scope.key = '';
+            scope.initialized = false;
+            scope.fields = 'id,num-connections,picture-url';
+            scope.lang = 'en_US';
+            scope.init = function() {
+                scope.initialized = true;
+            };
+            scope.stringify = function(obj) {
+                return JSON.stringify(obj);
+            };
+		</script>
+	</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -37,12 +37,12 @@
                 </div>
                 <paper-button on-tap="init" raised disabled="[[initialized]]">Start</paper-button>
 
-                <div class="init-hint" hidden=[[!initialized]]>The key can't be changed once the LinkedIn element was initialized. Reload this page to use another key.</div>
+                <div class="init-hint" hidden="[[!initialized]]">The key can't be changed once the LinkedIn element was initialized. Reload this page to use another key.</div>
             </div>
 
             <h2>Step 2: Try element</h2>
             <div class="vertical-section">
-                <div hidden=[[initialized]]>Enter your LinkedIn key and click the [Start] button</div>
+                <div hidden="[[initialized]]">Enter your LinkedIn key and click the [Start] button</div>
 
                 <template is="dom-if" if="[[initialized]]">
                     <linkedin-signin

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-	<head>
+    <head>
         <title>linkedin-signin</title>
 
         <meta charset="utf-8">
@@ -23,10 +23,10 @@
                 margin-top: 20px;
             }
         </style>
-	</head>
+    </head>
 
-	<body>
-		<template is="dom-bind">
+    <body>
+        <template is="dom-bind">
             <h2>Step 1: Configure element</h2>
             <div class="vertical-section">
                 <div class="input">
@@ -82,7 +82,7 @@
                     [[stringify(oAuthData)]]
                 </div>
             </div>
-		</template>
+        </template>
 
         <script>
             var scope = document.querySelector('template[is=dom-bind]');
@@ -96,6 +96,6 @@
             scope.stringify = function(obj) {
                 return JSON.stringify(obj);
             };
-		</script>
-	</body>
+        </script>
+    </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -41,11 +41,15 @@
             </div>
 
             <h2>Step 2: Try element</h2>
-            <div class="vertical-section">
-                <div hidden="[[initialized]]">Enter your LinkedIn key and click the [Start] button</div>
+            <div class="vertical-section" hidden="[[initialized]]">
+                Enter your LinkedIn key and click the [Start] button
+            </div>
 
-                <template is="dom-if" if="[[initialized]]">
+            <template is="dom-if" if="[[initialized]]">
+                <h4>Standard LinkedIn button</h4>
+                <div class="vertical-section">
                     <linkedin-signin
+                        id="signin"
                         client-id="[[key]]"
                         fields="[[fields]]"
                         authorize="[[authorize]]"
@@ -56,8 +60,15 @@
                         error="{{error}}"
                         o-auth-data="{{oAuthData}}">
                     </linkedin-signin>
-                </template>
-            </div>
+                </div>
+
+                <h4>Custom button</h4>
+                <div class="vertical-section">
+                    <paper-button raised on-tap="onCustomSignin">Signin</paper-button>
+                    <br><br><br>
+                    Set the hidden attribute on the &lt;linkedin-signin&gt; element if you use your own button.
+                </div>
+            </template>
 
             <div class="vertical-section-container" hidden="[[!initialized]]">
                 <h2>Exposed properties</h2>
@@ -92,6 +103,10 @@
             scope.lang = 'en_US';
             scope.init = function() {
                 scope.initialized = true;
+            };
+            scope.onCustomSignin = function() {
+                var signin = document.querySelector('#signin');
+                signin.signIn();
             };
             scope.stringify = function(obj) {
                 return JSON.stringify(obj);

--- a/linkedin-signin.html
+++ b/linkedin-signin.html
@@ -148,7 +148,7 @@ LinkedInSignIn = Polymer({
 		buttonScript.setAttribute("type", "IN/Login");
 		this.appendChild(buttonScript);
 
-		if (window.IN && window.IN.parse) {
+		if (window.IN) {
 			initLinkedIn();
 			IN.parse(this);
 			this._restyleButton();

--- a/linkedin-signin.html
+++ b/linkedin-signin.html
@@ -136,7 +136,7 @@ LinkedInSignIn = Polymer({
 		var self = this,
 			initLinkedIn = function() {
 				IN.Event.on(IN, 'auth', self._onSignedIn, self);
-				IN.Event.on(IN, 'systemReady', function(){console.info('systemReady!');self._restyleButton();}, self);
+				IN.Event.on(IN, 'systemReady', function(){self._restyleButton();}, self);
 				IN.Event.on(IN, 'logout', function() {
 					self.async(self._restyleButton, 0);
 				}, self);

--- a/linkedin-signin.html
+++ b/linkedin-signin.html
@@ -148,7 +148,7 @@ LinkedInSignIn = Polymer({
 		buttonScript.setAttribute("type", "IN/Login");
 		this.appendChild(buttonScript);
 
-		if (window.IN) {
+		if (window.IN && window.IN.parse) {
 			initLinkedIn();
 			IN.parse(this);
 			this._restyleButton();


### PR DESCRIPTION
Web Component Tests that use the `<linkedin-signin>` element fail currently because `window.IN` gets initialized but not loaded.
